### PR TITLE
feat(timer): alerta visual nas transições de pomodoro e flow

### DIFF
--- a/specs/pomodoro-transition-alerts/plan.md
+++ b/specs/pomodoro-transition-alerts/plan.md
@@ -1,0 +1,158 @@
+# Pomodoro Transition Alerts — Plano técnico
+
+**Status**: done
+**Spec**: ./spec.md
+
+## Resumo da abordagem
+
+Adicionar uma camada de alerta — notificação OS + dock bounce / flashFrame — disparada nas transições já existentes do `pomodoroStore` e `flowStore`. A detecção de transição **já está implementada** em `PomodoroTimer.tsx` e `FlowTimer.tsx` (via `prevStatusRef`/`prevPhaseRef`), pelo que o trabalho concentra-se em criar um serviço novo no renderer e um único canal IPC para o main disparar atenção visual nativa. O som actual fica intocado.
+
+## Layer 1 — Schema Markdown (iCloud)
+
+**Sem alterações.** A feature é puramente de UX/notificação — não afecta o formato dos ficheiros `~/Bloc/YYYY/YYYY-MM-DD.md` nem `Bloc-Blocks.md`. Não há estado novo a persistir nem dados a serializar.
+
+## Layer 2 — Stores Zustand (renderer)
+
+**Sem alterações estruturais.** As transições já existem:
+
+- `pomodoroStore.ts:96-110` — `tick()` transita `working → break` e `break → idle`
+- `flowStore.ts:327-360` — `tick()` transita `working → break` e `break → working`
+
+Não adicionamos campos, acções, nem persistência. Os componentes `PomodoroTimer` e `FlowTimer` já observam estas transições (`prevStatusRef` / `prevPhaseRef` em useEffect) — vamos pendurar o novo trigger no mesmo sítio onde hoje se chama `playWorkDoneSound()` / `playBreakDoneSound()`.
+
+## Layer 3 — IPC main↔renderer
+
+### Novo canal
+
+**`alert-attention`** (renderer → main, fire-and-forget via `ipcMain.on`)
+
+- **Input**: nenhum (a chamada significa "chama atenção, qualquer plataforma")
+- **Comportamento no main**:
+  - macOS: `app.dock?.bounce('critical')` — bounce contínuo até o utilizador focar o Bloc (decisão revista durante teste manual: o pulso único era demasiado subtil)
+  - Windows: `mainWindow.flashFrame(true)` (e `flashFrame(false)` quando a janela ganha foco — registado uma vez no setup)
+  - Linux: no-op (sem equivalente fiável)
+  - **Guard**: se `mainWindow?.isFocused()` for `true`, não faz nada (defesa em profundidade — o renderer também filtra)
+- **Sem retorno** — fire-and-forget. Falha silenciosa se main não estiver pronto.
+
+### Reutilizado (já existe)
+
+**`focus-window`** (`main/index.ts:232-237`, exposto como `bloc.focusWindow()` em preload) — usado no `onclick` da notificação para trazer o Bloc para foreground. Sem alterações.
+
+### Setup adicional no main
+
+- No `createWindow()`, registar listener `mainWindow.on('focus', () => mainWindow.flashFrame(false))` para parar o flash do Windows quando o utilizador volta à app.
+
+### Preload
+
+Adicionar em `bloc` (ficheiro `src/preload/index.ts`):
+
+```ts
+alertAttention: () => {
+  ipcRenderer.send('alert-attention')
+}
+```
+
+E no tipo correspondente (ver `src/renderer/types/electron.d.ts` ou onde estiver declarado o `window.bloc`).
+
+## Layer 4 — MCP server
+
+**Sem alterações.** O MCP server (`mcp-server/`) lida com leitura/escrita de ficheiros markdown (dias, blocos, tasks). Notificações de transições do timer são puramente de UX local e não fazem parte da superfície que o MCP expõe.
+
+> Confirmado: nenhuma tool MCP toca em `pomodoroStore`/`flowStore` ou nas transições.
+
+## UI / componentes
+
+### Novo serviço — `src/renderer/services/transitionAlert.ts`
+
+Módulo único responsável por disparar o pulso visual. Mantém-se separado de `notificationSound.ts` (que continua a tratar do som).
+
+API:
+
+```ts
+export function alertWorkDone(): void
+export function alertBreakDone(): void
+```
+
+Comportamento de cada função:
+
+1. Se `document.hasFocus()` → **return** (Bloc está em foreground, som basta)
+2. Tenta criar `new Notification(title, { body, icon, silent: true })`
+   - `silent: true` porque o som já é tratado por `notificationSound.ts`
+   - `icon`: caminho do ícone da app (reutilizado — não criamos ícones novos para manter o scope pequeno; a distinção fica no título/corpo)
+   - **`alertWorkDone`**: title `'Bloc — Hora da pausa'`, body com a duração da pausa (ex: `'Pausa de 5 min'`)
+   - **`alertBreakDone`**: title `'Bloc — De volta ao foco'`, body curto (ex: `'A pausa terminou.'`)
+3. `notification.onclick = () => window.bloc?.focusWindow()`
+4. Chama `window.bloc?.alertAttention()` (dock bounce / flashFrame)
+5. Falha silenciosa se Notification API estiver indisponível ou permissão negada — outras camadas (som) continuam a funcionar
+
+A duração da pausa é lida via parâmetro (`alertWorkDone(breakMinutes: number)`) para o body ser preciso. Cada timer passa o valor que tem.
+
+### Componentes alterados
+
+**`src/renderer/components/PomodoroTimer.tsx`** (linhas 38-47)
+
+No `useEffect` de transições, adicionar a chamada ao alerta a seguir ao som:
+
+```ts
+if (prev === 'working' && status === 'break') {
+  playWorkDoneSound()
+  alertWorkDone(breakDuration)
+} else if (prev === 'break' && status === 'idle') {
+  playBreakDoneSound()
+  alertBreakDone()
+}
+```
+
+(`breakDuration` é obtido do store — já é `usePomodoroStore((s) => s.breakDuration)`.)
+
+**`src/renderer/components/FlowTimer.tsx`** (linhas 45-50)
+
+Equivalente:
+
+```ts
+if (prev === 'working' && phase === 'break') {
+  playWorkDoneSound()
+  alertWorkDone(breakDurationMinutes)
+}
+if (prev === 'break' && phase === 'working') {
+  playBreakDoneSound()
+  alertBreakDone()
+}
+```
+
+### Atalhos / tray / menus
+
+Sem alterações.
+
+### Estados de loading / erro / vazio
+
+- Se a permissão de notificação estiver negada (`Notification.permission === 'denied'`) → `transitionAlert` continua chamando `alertAttention` (dock bounce / flashFrame) e o som mantém-se. Sem UI de erro, sem prompt de permissão (a app já criou a permissão durante a feature de idle detection).
+
+## Verificação
+
+### Manual
+
+1. **Setup**: garantir que a permissão de notificação está concedida (via prompt anterior do idle, ou conceder em System Settings → Notifications → Bloc).
+2. **Pomodoro standalone**:
+   - Iniciar pomodoro com duração curta (ex: 1 min de teste — alterar localmente no setting ou usar duração default).
+   - Mudar de janela (browser, terminal, etc.) e esperar o fim do pomodoro.
+   - **Esperado**: notificação OS "Hora da pausa", dock saltar uma vez (macOS), som actual a tocar.
+   - Clicar na notificação → Bloc volta para foreground.
+3. **Repetir para fim do break** com Bloc não-focado → notificação "De volta ao foco".
+4. **Verificar supressão**: deixar o Bloc focado durante uma transição → notificação **não** dispara, dock **não** salta, mas o som toca.
+5. **Flow timer**: iniciar Flow com várias tasks, durações curtas, e validar transições focus↔break com Bloc não-focado.
+6. **Permissão negada**: revogar permissão de notificação no SO → confirmar que dock bounce e som continuam a funcionar; nenhuma exception.
+7. **Windows** (se possível): mesmo fluxo, esperar `flashFrame` na taskbar.
+
+### Automatizada
+
+Não introduzimos testes automatizados nesta feature — o comportamento é nativo (Notification API, electron `dock`/`flashFrame`) e difícil de mockar sem grande infraestrutura. Tratamos isto como tradeoff aceitável para o scope.
+
+## Riscos e alternativas
+
+- **Risco — múltiplos disparos**: se ambos `pomodoroStore` e `flowStore` estiverem activos simultaneamente (improvável, mas possível?), pode disparar duas notificações ao mesmo tempo. Mitigação: comportamento dos stores actuais já é mutuamente exclusivo no fluxo normal; deixamos como está, e se aparecer empiricamente adicionamos um debounce no serviço.
+- **Decisão revista (durante teste manual) — `dock.bounce('critical')`**: `'informational'` revelou-se demasiado subtil (um único salto passa despercebido). Mudámos para `'critical'`, que salta até o utilizador focar a janela. Alinha-se com o comportamento default do `flashFrame(true)` no Windows (também contínuo até foreground).
+- **Risco — `flashFrame` não pára**: se não registarmos o listener `on('focus')` para chamar `flashFrame(false)`, o Windows continua a piscar. Mitigação: incluído no setup do main.
+- **Alternativa rejeitada — disparar tudo do main process**: poderíamos mover a Notification para o main (`new Notification` do Electron). Rejeitada porque (a) o renderer já usa `new Notification()` (browser API) consistentemente em `App.tsx:315` e (b) adicionar mais um canal IPC apenas para a notificação é overhead sem benefício.
+- **Alternativa rejeitada — ícones distintos por transição**: criar `notif-focus.png` e `notif-break.png`. Rejeitada para manter scope pequeno; distinção fica no título/corpo. Pode ser revisitado se houver fricção.
+- **Alternativa rejeitada — setting para desligar**: spec já confirmou que fica fora de scope inicial.

--- a/specs/pomodoro-transition-alerts/spec.md
+++ b/specs/pomodoro-transition-alerts/spec.md
@@ -1,0 +1,84 @@
+---
+name: Pomodoro Transition Alerts
+description: Alerta visual reforçado nas transições do pomodoro/flow para garantir que o utilizador percebe o fim do focus/break mesmo quando está noutra aplicação
+type: project
+---
+
+# Pomodoro Transition Alerts
+
+**Status**: done
+**Criado**: 2026-05-01
+
+## Problema
+
+O som actual tocado nas transições do pomodoro (e do Flow) é insuficiente para chamar a atenção do utilizador quando este está a trabalhar noutra aplicação (browser, IDE, etc.). Resultado: pomodoros que se prolongam para lá do tempo, breaks que passam sem ser notados, e quebra do ciclo de foco/descanso que é o propósito da feature.
+
+## Utilizador e cenário
+
+O próprio utilizador do Bloc — alguém que tem o Bloc a correr em background com um pomodoro/flow activo enquanto trabalha noutras apps (geralmente em fullscreen ou ocupando outro monitor). No momento da transição, a janela do Bloc não está visível e o som por si só passa despercebido (ruído ambiente, headphones com áudio de meeting/música, etc.).
+
+## Solução proposta (alto nível)
+
+Adicionar um **pulso único** de alertas nas transições do pomodoro e do Flow, combinando três camadas:
+
+1. **Notificação nativa do sistema operativo** — uma para cada tipo de transição, com título/corpo/ícone distintos:
+   - Fim do focus → "Hora da pausa" (verde/relax)
+   - Fim do break → "De volta ao foco" (cor accent do Bloc)
+2. **Dock bounce no macOS / `flashFrame` no Windows** — uma vez, para chamar atenção visual mesmo quando o utilizador está focado noutra app.
+3. **Click na notificação traz o Bloc para foreground** — para o utilizador conseguir ver o estado actual com um clique.
+
+O **som actual mantém-se inalterado** e continua a tocar em paralelo. Estas camadas adicionam-se ao que existe, não substituem.
+
+## Fluxo principal
+
+### Fim do focus (working → break)
+1. Pomodoro/Flow chega a `secondsRemaining === 0` em estado `working`
+2. Estado transita para `break` (comportamento actual mantém-se)
+3. Som de "work done" toca (comportamento actual mantém-se)
+4. **Novo**: notificação nativa do SO dispara: título "Hora da pausa", corpo com duração da pausa
+5. **Novo**: dock bounce (macOS) ou flashFrame (Windows) é disparado uma vez
+6. Se o utilizador clicar na notificação → Bloc traz a janela para foreground
+
+### Fim do break (break → idle/working)
+1. Break chega a `secondsRemaining === 0`
+2. Estado transita para `idle` (pomodoroStore) ou `working` (flowStore, próximo ciclo)
+3. Som de "break done" toca
+4. **Novo**: notificação nativa do SO dispara: título "De volta ao foco", corpo apropriado
+5. **Novo**: dock bounce / flashFrame
+6. Click traz Bloc para foreground
+
+### Quando o Bloc já está focado
+Se a janela do Bloc é a app activa no momento da transição, **a notificação nativa e o dock bounce/flashFrame não disparam** — o som basta e o utilizador já está a ver o estado.
+
+## Casos extremos / fora de âmbito
+
+**Cobre:**
+- Transições do `pomodoroStore` (timer pomodoro standalone)
+- Transições do `flowStore` (Flow tracking de tasks)
+- Ambas as plataformas: macOS (dock bounce) e Windows (flashFrame)
+- Linux: cai para apenas notificação nativa (sem flash equivalente fiável)
+- Permissão de notificações: usa o que já está em uso para a notificação de "inatividade detectada"
+
+**Não cobre (por agora):**
+- **Modo persistente / despertador** — explicitamente fora de scope. Decidido: pulso único só.
+- **Detecção de meetings/Zoom/Focus mode** — explicitamente fora de scope.
+- **Setting para desligar as notificações** — fora de scope inicial; pode ser adicionado depois se houver fricção.
+- **Customização de sons / ícones / títulos pelo utilizador** — fora de scope.
+- **Notificações para outros eventos** (ex: idle detection já existe e mantém-se como está).
+
+## Critérios de aceitação
+
+- [ ] Quando um pomodoro acaba (focus → break) com o Bloc não-focado, dispara: notificação OS com título distinto de focus, dock bounce (macOS) ou flashFrame (Windows), e o som actual continua a tocar.
+- [ ] Quando um break acaba com o Bloc não-focado, dispara: notificação OS com título distinto de break, dock bounce / flashFrame, e o som actual continua a tocar.
+- [ ] As notificações de fim-de-focus e fim-de-break são visualmente distinguíveis (título e/ou ícone diferentes).
+- [ ] Click na notificação traz a janela do Bloc para foreground (foco + restore se minimizado).
+- [ ] Quando o Bloc é a aplicação focada no momento da transição, não dispara notificação nem dock bounce/flashFrame (apenas o som actual).
+- [ ] Funciona tanto para `pomodoroStore` (timer standalone) como para `flowStore` (Flow de tarefas).
+- [ ] O som actual e o comportamento existente das transições não mudam.
+- [ ] Permissão de notificação (caso negada pelo SO) falha silenciosamente — o resto do fluxo (estado, som, dock bounce) continua a funcionar.
+
+## Questões em aberto
+
+- **Onde dispara o pulso (renderer vs main)?** A notificação nativa pode ser disparada do renderer (Notification API web, já em uso em `App.tsx:315`) mas o `flashFrame` e `dock.bounce` exigem main process — vamos precisar de um canal IPC novo. Decisão técnica para o plan.
+- **Ícones das notificações** — usar `build/icon.png` para ambas, ou criar dois ícones distintos (ex: `build/notif-focus.png`, `build/notif-break.png`)? Decisão para o plan; default é reutilizar o ícone existente para não inflar o scope.
+- **Detecção de "Bloc focado"** — `BrowserWindow.isFocused()` no main, ou `document.hasFocus()` no renderer? Decisão para o plan.

--- a/specs/pomodoro-transition-alerts/tasks.md
+++ b/specs/pomodoro-transition-alerts/tasks.md
@@ -1,0 +1,111 @@
+# Pomodoro Transition Alerts — Tasks
+
+**Status**: done
+**Plan**: ./plan.md
+
+## Ordem de execução
+
+> Layers 1 (markdown), 2 (stores) e 4 (MCP) **não têm alterações** nesta feature. O trabalho começa directamente em IPC + tipos partilhados, segue para o serviço novo no renderer, e termina no wire-up dos dois componentes timer e na verificação manual.
+
+### 1. IPC main↔renderer
+
+- [x] **T1.1** — Adicionar handler `alert-attention` no main process
+  - Ficheiro: `src/main/index.ts`
+  - Local: dentro do `app.whenReady().then(...)`, perto dos outros `ipcMain.on(...)` (linhas ~223-237)
+  - Comportamento:
+    - Se `mainWindow?.isFocused()` → `return` (no-op)
+    - macOS: `if (process.platform === 'darwin') app.dock?.bounce('informational')`
+    - Windows: `if (process.platform === 'win32') mainWindow?.flashFrame(true)`
+    - Linux: sem acção
+  - Verificação: `npm run typecheck` passa; `console.log` temporário no handler confirma chegada do evento durante teste manual.
+
+- [x] **T1.2** — Registar listener `mainWindow.on('focus', ...)` para parar `flashFrame` no Windows
+  - Ficheiro: `src/main/index.ts`
+  - Local: dentro de `createWindow()`, junto aos outros listeners de `mainWindow.on(...)` (linhas 135-149)
+  - Código: `mainWindow.on('focus', () => { if (process.platform === 'win32') mainWindow?.flashFrame(false) })`
+  - Verificação: typecheck passa.
+
+- [x] **T1.3** — Expor `alertAttention()` no preload
+  - Ficheiro: `src/preload/index.ts`
+  - Local: dentro do objecto `bloc`, perto de `focusWindow` (linha 26-28)
+  - Código:
+    ```ts
+    alertAttention: () => {
+      ipcRenderer.send('alert-attention')
+    }
+    ```
+  - Verificação: typecheck passa.
+
+- [x] **T1.4** — Estender o tipo global `Window['bloc']`
+  - Ficheiro: `src/renderer/App.tsx`
+  - Local: dentro do `declare global` (linha 29-74), depois de `focusWindow: () => void`
+  - Código: `alertAttention: () => void`
+  - Verificação: typecheck passa; `window.bloc?.alertAttention` autocompletes em `*.tsx`.
+
+### 2. Serviço novo no renderer
+
+- [x] **T2.1** — Criar `src/renderer/services/transitionAlert.ts`
+  - Exporta duas funções:
+    ```ts
+    export function alertWorkDone(breakMinutes: number): void
+    export function alertBreakDone(): void
+    ```
+  - Comportamento partilhado (helper interno):
+    1. Se `document.hasFocus()` → return
+    2. Try/catch em torno de `new Notification(title, { body, icon, silent: true })` — falha silenciosa se permissão negada ou API indisponível
+    3. `notification.onclick = () => window.bloc?.focusWindow()`
+    4. `window.bloc?.alertAttention()`
+  - Strings (em PT, alinhado com locale):
+    - `alertWorkDone`: title `'Bloc — Hora da pausa'`, body `\`Pausa de ${breakMinutes} min\``
+    - `alertBreakDone`: title `'Bloc — De volta ao foco'`, body `'A pausa terminou.'`
+  - Ícone: tentar resolver através do que já existe (sem novos ficheiros) — se simplesmente não passarmos `icon`, o SO usa o ícone da app, o que é aceitável e mais simples.
+  - Verificação: typecheck passa; ficheiro segue o estilo de `notificationSound.ts`.
+
+### 3. Wire-up nos componentes timer
+
+- [x] **T3.1** — `PomodoroTimer.tsx`: chamar alertas a seguir aos sons
+  - Ficheiro: `src/renderer/components/PomodoroTimer.tsx`
+  - Local: useEffect de transições (linhas 38-47)
+  - Adicionar import: `import { alertWorkDone, alertBreakDone } from '../services/transitionAlert'`
+  - Adicionar selector do store: `const breakDuration = usePomodoroStore((s) => s.breakDuration)` (se ainda não estiver presente — verificar antes de duplicar)
+  - Após `playWorkDoneSound()` → `alertWorkDone(breakDuration)`
+  - Após `playBreakDoneSound()` → `alertBreakDone()`
+  - Verificação: typecheck passa; comportamento existente (som) inalterado em runtime.
+
+- [x] **T3.2** — `FlowTimer.tsx`: chamar alertas a seguir aos sons
+  - Ficheiro: `src/renderer/components/FlowTimer.tsx`
+  - Local: useEffect de transições (linhas 44-50)
+  - Adicionar import equivalente
+  - Obter duração da pausa do `flowStore` — verificar nome do campo (provavelmente `breakDurationMinutes` ou similar; ler o store antes de assumir)
+  - Após `playWorkDoneSound()` → `alertWorkDone(breakDuration)`
+  - Após `playBreakDoneSound()` → `alertBreakDone()`
+  - Verificação: typecheck passa.
+
+### 4. Verificação manual
+
+- [x] **T4.1** — Build/typecheck end-to-end
+  - Correr `npm run build` (ou `npm run typecheck` se existir) — confirmar zero errors em main, preload e renderer.
+
+- [x] **T4.2** — Teste pomodoro standalone (Bloc não-focado)
+  - Abrir `npm run dev`, iniciar pomodoro (reduzir duração para teste se possível, ex: editar localmente para 1 min de focus + 1 min de break).
+  - Mudar para outra app (browser).
+  - Fim do focus → confirmar: notificação OS "Bloc — Hora da pausa", dock bounce uma vez (macOS), som actual a tocar.
+  - Clicar na notificação → Bloc volta para foreground.
+  - Fim do break → confirmar: notificação "Bloc — De volta ao foco", dock bounce, som.
+
+- [x] **T4.3** — Teste de supressão (Bloc focado)
+  - Repetir o ciclo com a janela do Bloc focada durante a transição.
+  - Confirmar: **sem** notificação, **sem** dock bounce, mas som actual continua a tocar.
+
+- [x] **T4.4** — Teste Flow timer
+  - Iniciar Flow com 2-3 tasks (durações curtas), Bloc não-focado.
+  - Validar transições focus↔break disparam notificações distintas.
+
+- [x] **T4.5** — Permissão de notificação negada
+  - Em System Settings → Notifications → Bloc, revogar permissão.
+  - Repetir T4.2.
+  - Esperado: nenhuma exception no console; dock bounce e som continuam a funcionar; só a notificação OS fica suprimida.
+
+- [x] **T4.6** — Limpeza e final
+  - Remover qualquer `console.log` temporário adicionado em T1.1.
+  - Marcar todos os ficheiros do spec como `Status: done`.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -143,6 +143,10 @@ rm -rf "$TEMP_DIR"
       mainWindow = null
     })
 
+    mainWindow.on('focus', () => {
+      if (process.platform === 'win32') mainWindow?.flashFrame(false)
+    })
+
     mainWindow.webContents.setWindowOpenHandler((details) => {
       shell.openExternal(details.url)
       return { action: 'deny' }
@@ -234,6 +238,15 @@ rm -rf "$TEMP_DIR"
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.show()
       mainWindow.focus()
+    })
+
+    ipcMain.on('alert-attention', () => {
+      if (!mainWindow || mainWindow.isFocused()) return
+      if (process.platform === 'darwin') {
+        app.dock?.bounce('critical')
+      } else if (process.platform === 'win32') {
+        mainWindow.flashFrame(true)
+      }
     })
 
     globalShortcut.register('CommandOrControl+,', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,9 @@ if (process.contextIsolated) {
       focusWindow: () => {
         ipcRenderer.send('focus-window')
       },
+      alertAttention: () => {
+        ipcRenderer.send('alert-attention')
+      },
       onUpdateAvailable: (callback: (version: string) => void) => {
         const handler = (_event: Electron.IpcRendererEvent, version: string) => callback(version)
         ipcRenderer.on('update-available', handler)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,6 +31,7 @@ declare global {
     bloc?: {
       getAppVersion: () => string
       focusWindow: () => void
+      alertAttention: () => void
       onNavigate: (callback: (path: string) => void) => () => void
       onQuickCapture: (callback: () => void) => () => void
       updatePomodoroTray: (time: string | null, status: string | null) => void

--- a/src/renderer/components/FlowTimer.tsx
+++ b/src/renderer/components/FlowTimer.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef } from 'react'
 import { Play, Pause, Square, SkipForward } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useFlowStore } from '../stores/flowStore'
+import { usePomodoroStore } from '../stores/pomodoroStore'
 import { playWorkDoneSound, playBreakDoneSound, playCountdownTick } from '../services/notificationSound'
+import { alertWorkDone, alertBreakDone } from '../services/transitionAlert'
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
@@ -27,6 +29,7 @@ export default function FlowTimer({ compact }: FlowTimerProps) {
   const skipCurrentTask = useFlowStore((s) => s.skipCurrentTask)
   const secondsRemaining = useFlowStore((s) => s.secondsRemaining)
   const completedPomodoros = useFlowStore((s) => s.completedPomodoros)
+  const breakDuration = usePomodoroStore((s) => s.breakDuration)
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -45,9 +48,15 @@ export default function FlowTimer({ compact }: FlowTimerProps) {
   useEffect(() => {
     const prev = prevPhaseRef.current
     prevPhaseRef.current = phase
-    if (prev === 'working' && phase === 'break') playWorkDoneSound()
-    if (prev === 'break' && phase === 'working') playBreakDoneSound()
-  }, [phase])
+    if (prev === 'working' && phase === 'break') {
+      playWorkDoneSound()
+      alertWorkDone(breakDuration)
+    }
+    if (prev === 'break' && phase === 'working') {
+      playBreakDoneSound()
+      alertBreakDone()
+    }
+  }, [phase, breakDuration])
 
   useEffect(() => {
     if (secondsRemaining <= 10 && secondsRemaining > 0 && !isPaused && isActive) {

--- a/src/renderer/components/PomodoroTimer.tsx
+++ b/src/renderer/components/PomodoroTimer.tsx
@@ -4,6 +4,7 @@ import { Play, Pause, Square, Check } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { usePomodoroStore } from '../stores/pomodoroStore'
 import { playWorkDoneSound, playBreakDoneSound, playCountdownTick } from '../services/notificationSound'
+import { alertWorkDone, alertBreakDone } from '../services/transitionAlert'
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
@@ -14,6 +15,7 @@ function formatTime(seconds: number): string {
 /** Core timer UI — works with any date source */
 export function PomodoroTimerCore({ date }: { date?: string }) {
   const { status, isPaused, secondsRemaining } = usePomodoroStore()
+  const breakDuration = usePomodoroStore((s) => s.breakDuration)
   const startWork = usePomodoroStore((s) => s.startWork)
   const pause = usePomodoroStore((s) => s.pause)
   const resume = usePomodoroStore((s) => s.resume)
@@ -41,10 +43,12 @@ export function PomodoroTimerCore({ date }: { date?: string }) {
 
     if (prev === 'working' && status === 'break') {
       playWorkDoneSound()
+      alertWorkDone(breakDuration)
     } else if (prev === 'break' && status === 'idle') {
       playBreakDoneSound()
+      alertBreakDone()
     }
-  }, [status])
+  }, [status, breakDuration])
 
   // Countdown tick in last 10 seconds
   useEffect(() => {

--- a/src/renderer/services/transitionAlert.ts
+++ b/src/renderer/services/transitionAlert.ts
@@ -1,0 +1,24 @@
+function showNotification(title: string, body: string): void {
+  if (typeof document !== 'undefined' && document.hasFocus()) return
+
+  try {
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') {
+      window.bloc?.alertAttention()
+      return
+    }
+    const n = new Notification(title, { body, silent: true })
+    n.onclick = () => window.bloc?.focusWindow()
+  } catch {
+    // Notification API unavailable or threw — fall through to attention bounce
+  }
+
+  window.bloc?.alertAttention()
+}
+
+export function alertWorkDone(breakMinutes: number): void {
+  showNotification('Bloc — Hora da pausa', `Pausa de ${breakMinutes} min`)
+}
+
+export function alertBreakDone(): void {
+  showNotification('Bloc — De volta ao foco', 'A pausa terminou.')
+}


### PR DESCRIPTION
## Summary
- Notificação nativa do SO + dock bounce contínuo (macOS) / flashFrame (Windows) quando o pomodoro ou flow timer transita e o Bloc está fora de foco.
- Click na notificação traz o Bloc para foreground.
- Suprimido quando o Bloc já está focado — só toca o som actual.
- Som existente mantém-se inalterado; cobre `pomodoroStore` e `flowStore`.

## Test plan
- [x] Build passa (`npm run build`)
- [x] Pomodoro standalone: notificação + dock bounce com Bloc não-focado
- [x] Supressão: Bloc focado → só som
- [x] Flow timer: transições focus↔break disparam alertas
- [x] Permissão de notificação negada → dock bounce e som continuam

🤖 Generated with [Claude Code](https://claude.com/claude-code)