### PR TITLE
fix(gcal): withRetry efectivo nas mutações Google Calendar

### DIFF
--- a/src/renderer/services/gcalIpc.ts
+++ b/src/renderer/services/gcalIpc.ts
@@ -1,0 +1,56 @@
+/**
+ * IPC mutations return `{ success: boolean, ... }` instead of rejecting.
+ * These helpers throw on failure so callers (e.g. withRetry) see real errors.
+ */
+
+type GcalFail = { success: false; error?: string }
+type GcalCreateOk = { success: true; event: unknown }
+type GcalMutationOk = { success: true; event?: unknown }
+
+function requireGcalBridge(): NonNullable<Window['bloc']>['gcal'] {
+  const g = window.bloc?.gcal
+  if (!g) throw new Error('Google Calendar indisponível neste ambiente')
+  return g
+}
+
+export async function gcalCreateEvent(
+  calendarId: string,
+  eventData: {
+    summary: string
+    start: { dateTime: string; timeZone?: string }
+    end: { dateTime: string; timeZone?: string }
+    colorId?: string
+    visibility?: 'private' | 'public' | 'default' | 'confidential'
+  }
+): Promise<{ event: unknown }> {
+  const res = (await requireGcalBridge().createEvent(calendarId, eventData)) as GcalCreateOk | GcalFail
+  if (!res || res.success !== true) {
+    throw new Error((res as GcalFail)?.error ?? 'Falha ao criar evento no Google Calendar')
+  }
+  if (!res.event) throw new Error('Resposta inválida ao criar evento no Google Calendar')
+  return { event: res.event }
+}
+
+export async function gcalUpdateEvent(
+  calendarId: string,
+  eventId: string,
+  eventData: {
+    summary?: string
+    start?: { dateTime: string; timeZone?: string }
+    end?: { dateTime: string; timeZone?: string }
+    colorId?: string
+    visibility?: 'private' | 'public' | 'default' | 'confidential'
+  }
+): Promise<void> {
+  const res = (await requireGcalBridge().updateEvent(calendarId, eventId, eventData)) as GcalMutationOk | GcalFail
+  if (!res || res.success !== true) {
+    throw new Error((res as GcalFail)?.error ?? 'Falha ao atualizar evento no Google Calendar')
+  }
+}
+
+export async function gcalDeleteEvent(calendarId: string, eventId: string): Promise<void> {
+  const res = (await requireGcalBridge().deleteEvent(calendarId, eventId)) as GcalMutationOk | GcalFail
+  if (!res || res.success !== true) {
+    throw new Error((res as GcalFail)?.error ?? 'Falha ao eliminar evento no Google Calendar')
+  }
+}

--- a/src/renderer/services/googleCalendarSync.ts
+++ b/src/renderer/services/googleCalendarSync.ts
@@ -3,6 +3,7 @@ import { useGoogleCalendarStore } from '../stores/googleCalendarStore'
 import { format, parseISO, startOfDay, endOfDay } from 'date-fns'
 import { withRetry } from './syncRetry'
 import { blocColorToGcal, gcalColorToBloc } from './googleCalendarColors'
+import { gcalCreateEvent, gcalDeleteEvent, gcalUpdateEvent } from './gcalIpc'
 
 const LOCAL_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone
 
@@ -81,8 +82,8 @@ async function pushLocalBlocksToGcal(date: string, calendarId: string): Promise<
 
   for (const block of localOnly) {
     try {
-      const result = await withRetry(() =>
-        window.bloc?.gcal.createEvent(calendarId, {
+      const { event: created } = await withRetry(() =>
+        gcalCreateEvent(calendarId, {
           summary: block.title,
           start: { dateTime: minutesToDateTime(date, block.startTime), timeZone: LOCAL_TIMEZONE },
           end: { dateTime: minutesToDateTime(date, block.endTime), timeZone: LOCAL_TIMEZONE },
@@ -91,19 +92,17 @@ async function pushLocalBlocksToGcal(date: string, calendarId: string): Promise<
         })
       )
 
-      if (result?.success && result.event) {
-        const event = result.event as GCalEvent
-        // Update the block with the Google Event ID
-        const currentBlocks = useTimeBlockStore.getState().blocks[date] || []
-        const updated = currentBlocks.map((b) =>
-          b.id === block.id ? { ...b, googleEventId: event.id } : b
-        )
-        useTimeBlockStore.setState({
-          blocks: { ...useTimeBlockStore.getState().blocks, [date]: updated }
-        })
-        // Mark as just pushed so we don't re-push immediately
-        lastPushedAt.set(event.id, Date.now())
-      }
+      const event = created as GCalEvent
+      // Update the block with the Google Event ID
+      const currentBlocks = useTimeBlockStore.getState().blocks[date] || []
+      const updated = currentBlocks.map((b) =>
+        b.id === block.id ? { ...b, googleEventId: event.id } : b
+      )
+      useTimeBlockStore.setState({
+        blocks: { ...useTimeBlockStore.getState().blocks, [date]: updated }
+      })
+      // Mark as just pushed so we don't re-push immediately
+      lastPushedAt.set(event.id, Date.now())
     } catch (err) {
       console.error('[gcal-sync] Failed to push block to GCal:', err)
     }
@@ -123,7 +122,7 @@ async function pushUpdatedBlocksToGcal(date: string, calendarId: string): Promis
 
     try {
       await withRetry(() =>
-        window.bloc?.gcal.updateEvent(calendarId, gcalId, {
+        gcalUpdateEvent(calendarId, gcalId, {
           summary: block.title,
           start: { dateTime: minutesToDateTime(date, block.startTime), timeZone: LOCAL_TIMEZONE },
           end: { dateTime: minutesToDateTime(date, block.endTime), timeZone: LOCAL_TIMEZONE },
@@ -146,7 +145,7 @@ async function processPendingDeletes(calendarId: string): Promise<void> {
 
   for (const googleEventId of toDelete) {
     try {
-      await withRetry(() => window.bloc?.gcal.deleteEvent(calendarId, googleEventId))
+      await withRetry(() => gcalDeleteEvent(calendarId, googleEventId))
       lastPushedAt.delete(googleEventId)
     } catch (err) {
       console.error('[gcal-sync] Failed to delete event from GCal:', err)
@@ -382,7 +381,7 @@ function setupReactivePush(): void {
 
           try {
             await withRetry(() =>
-              window.bloc?.gcal.updateEvent(calId, googleEventId, {
+              gcalUpdateEvent(calId, googleEventId, {
                 summary: block.title,
                 start: { dateTime: minutesToDateTime(date, block.startTime), timeZone: LOCAL_TIMEZONE },
                 end: { dateTime: minutesToDateTime(date, block.endTime), timeZone: LOCAL_TIMEZONE },


### PR DESCRIPTION
## Resumo

As chamadas IPC `gcal:create-event`, `gcal:update-event` e `gcal:delete-event` devolvem `{ success: false }` **sem** rejeitar a promise, pelo que `withRetry()` nunca repetia tentativas em falhas da API.

## Alterações

- Novo `src/renderer/services/gcalIpc.ts`: `gcalCreateEvent`, `gcalUpdateEvent` e `gcalDeleteEvent` lançam `Error` quando `success !== true` (ou quando o bridge não existe).
- `googleCalendarSync.ts` usa estes helpers dentro de `withRetry`, alinhando o comportamento com o backoff documentado.
- Após um update/delete bem-sucedido via helper, `lastPushedAt` só é actualizado quando não há excepção (equivalente a `success === true` antes de marcarmos push).

## Verificação

- `npm run build`


Made with [Cursor](https://cursor.com)